### PR TITLE
feat: convert ngwaf gold-standard-starter to fastly terraform provider

### DIFF
--- a/gold-standard-starter/README.md
+++ b/gold-standard-starter/README.md
@@ -5,33 +5,34 @@
 * Utilizing the ASN header
 * Taking Advantage of the Proxy Headers
 * Optimize NGWAF enforcement with the Edge Cloud Network
-* The edge specific integration configurations are in [./gold-standard-starter/rules_with_edge_deployment.tf](/gold-standard-starter/rules_with_edge_deployment.tf)
+* The edge specific integration configurations are in [./rules_with_edge_deployment.tf](./rules_with_edge_deployment.tf)
 
 
-## Corp configurations
+## Account configurations
 * Request Rule that adds a Signal for requests that match on System Attacks AND frequent attack sources
 * Request Rule for a default geo-blocking policy
 * Request Rule that consolidates System Attacks under one Signal
 * Request Rule to tag a base set of Anomaly Signals
 
-## Site configurations
-* Site Alert that lowers thresholds for Any System Attack Signal
+## Workspace configurations
+* Workspace Thresholds that lower thresholds for Any System Attack Signal
 * Rate Limiting rule to detect enumeration attacks
 
 
 # Step 0 - Pre-requisites
 * [Clone this repo](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
 * [Install terraform](https://developer.hashicorp.com/terraform/downloads)
-* [Create an NGWAF API Key](https://docs.fastly.com/signalsciences/developer/using-our-api/#about-api-access-tokens)
+* [Create a Fastly API token](https://docs.fastly.com/en/guides/using-api-tokens) with service creation and management permissions
+* Ensure your NGWAF is accessible in the [Fastly control panel](https://manage.fastly.com) (unified account model)
 
 # Step 1
 Run `terraform init` within the gold-standard-starter directory
 
 # Step 2
 Run `terraform apply -parallelism=1` within the gold-standard-starter directory
-    - You will be prompted to enter details. Enter the appropriate information.
-    - You must respond with "yes" for the terraform configuration to actually apply
-Alternatively, you may run `terraform apply -parallelism=1 -var="NGWAF_CORP=YOUR_NGWAF_CORP_NAME" -var="NGWAF_SITE=YOUR_NGWAF_SITE_NAME" -var="NGWAF_EMAIL=YOUR_NGWAF_ACCOUNT_EMAIL"` and then enter your API key when prompted. Make sure to include `-parallelism=1` to avoid issues when applying many changes at the same time.
+- You will be prompted to enter details. Enter the appropriate information.
+- You must respond with "yes" for the terraform configuration to actually apply
+Alternatively, you may run `terraform apply -parallelism=1 -var="TF_VAR_NGWAF_WORKSPACE=YOUR_NGWAF_WORKSPACE_NAME"` and then enter your API key when prompted. Make sure to include `-parallelism=1` to avoid issues when applying many changes at the same time.
 
 # Need to restart?
-Just run `terraform destroy -parallelism=1` to delete any resources created by terraform after running `terraform apply -parallelism=1`. You may supply variables with the `terraform destroy -parallelism=1` command in the same fashion as in Step 2
+Just run `terraform destroy -parallelism=1` to delete any resources created by terraform after running `terraform apply -parallelism=1`.

--- a/gold-standard-starter/main.tf
+++ b/gold-standard-starter/main.tf
@@ -1,25 +1,31 @@
 # Try to follow recommended practices here, https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices
 
 #### Supply NGWAF API authentication - Start
-# environment variables must be available using "TF_VAR_*" in your terminal. 
-# For example, `echo $TF_VAR_NGWAF_CORP` should return your intended corp.
-provider "sigsci" {
-  corp       = var.NGWAF_CORP
-  email      = var.NGWAF_EMAIL
-  auth_token = var.NGWAF_TOKEN
+# environment variables must be available using "TF_VAR_*" in your terminal.
+# For example, `echo $TF_VAR_NGWAF_WORKSPACE` should return your intended corp.
+provider "fastly" {
+  # Authenticates via FASTLY_API_KEY environment variable.
+  # The NGWAF resources use the same API key as all other Fastly resources.
 }
 #### Supply NGWAF API authentication - End
 
-# resource "sigsci_site" "tenant_site" {
-#   short_name = var.NGWAF_SITE
-#   display_name = var.NGWAF_SITE
-#   block_duration_seconds = 86400
-#   agent_anon_mode = ""
-#   agent_level = "log"
-# }
+#### NGWAF Workspace - Start
+resource "fastly_ngwaf_workspace" "tenant_workspace" {
+  name        = var.NGWAF_WORKSPACE
+  description = "Fastly Gold Standard Starter"
+  mode        = "log"
+
+  attack_signal_thresholds {
+    one_minute  = 50
+    ten_minutes = 350
+    one_hour    = 1800
+    immediate   = false
+  }
+}
+#### NGWAF Workspace - End
 
 #### Block Any Attack Signal from Attack Sources - Start
-resource "sigsci_corp_list" "system-attack-signals-list" {
+resource "fastly_ngwaf_account_list" "system-attack-signals-list" {
   name = "system-attack-signals"
   type = "signal"
   entries = [
@@ -33,7 +39,7 @@ resource "sigsci_corp_list" "system-attack-signals-list" {
   ]
 }
 
-resource "sigsci_corp_list" "attack-sources-signals-list" {
+resource "fastly_ngwaf_account_list" "attack-sources-signals-list" {
   name = "attack-sources-signals"
   type = "signal"
   entries = [
@@ -43,52 +49,48 @@ resource "sigsci_corp_list" "attack-sources-signals-list" {
   ]
 }
 
-resource "sigsci_corp_signal_tag" "malicious-attacker-signal" {
-  short_name  = "malicious-attacker"
+resource "fastly_ngwaf_account_signal" "malicious-attacker-signal" {
+  name        = "malicious-attacker"
   description = "Identification of attacks from attacking IPs"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_rule" "malicious-attacker-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  group_operator   = "all"
-  enabled          = true
-  reason           = "Detect attacks from known attacking IPs"
-  expiration       = ""
+resource "fastly_ngwaf_account_rule" "malicious-attacker-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "Detect attacks from known attacking IPs"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
 
-
-  conditions {
-    type           = "multival"
+  multival_condition {
     field          = "signal"
     group_operator = "all"
     operator       = "exists"
 
-    conditions {
-      type     = "single"
-      field    = "signalType"
-      operator = "inList"
-      value    = sigsci_corp_list.system-attack-signals-list.id
+    condition {
+      field    = "signal_id"
+      operator = "in_list"
+      value    = "corp.${fastly_ngwaf_account_list.system-attack-signals-list.name}"
     }
-    conditions {
-      type     = "single"
-      field    = "signalType"
-      operator = "inList"
-      value    = sigsci_corp_list.attack-sources-signals-list.id
+    condition {
+      field    = "signal_id"
+      operator = "in_list"
+      value    = "corp.${fastly_ngwaf_account_list.attack-sources-signals-list.name}"
     }
   }
   # Easily go into blocking by uncommenting the following action
-  # actions {
+  # action {
   #   type = "block"
   # }
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.malicious-attacker-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.malicious-attacker-signal.name}"
   }
 
   depends_on = [
-    sigsci_corp_list.system-attack-signals-list,
-    sigsci_corp_list.attack-sources-signals-list,
+    fastly_ngwaf_account_list.system-attack-signals-list,
+    fastly_ngwaf_account_list.attack-sources-signals-list,
   ]
 }
 #### Block Any Attack Signal from Attack Sources - End
@@ -97,12 +99,13 @@ resource "sigsci_corp_rule" "malicious-attacker-rule" {
 
 #### Block Requests from Countries that are not revenue generating - Start
 # Also consider, https://home.treasury.gov/policy-issues/office-of-foreign-assets-control-sanctions-programs-and-information
-resource "sigsci_corp_signal_tag" "blocked-countries-corp-signal" {
-  short_name  = "blocked-countries"
+resource "fastly_ngwaf_account_signal" "blocked-countries-corp-signal" {
+  name        = "blocked-countries"
   description = "Block countries that are not revenue generating"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_list" "blocked-countries-corp-list" {
+resource "fastly_ngwaf_account_list" "blocked-countries-corp-list" {
   name = "blocked-countries"
   type = "country"
   entries = [
@@ -111,35 +114,33 @@ resource "sigsci_corp_list" "blocked-countries-corp-list" {
   description = "Block countries that are not revenue generating. KP is North Korea."
 }
 
-resource "sigsci_corp_rule" "blocked-countries-corp-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  enabled          = true
-  group_operator   = "all"
-  reason           = "Country Blocking Rule"
-  expiration       = ""
+resource "fastly_ngwaf_account_rule" "blocked-countries-corp-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "Country Blocking Rule"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
 
-  conditions {
-    type     = "single"
+  condition {
     field    = "country"
-    operator = "inList"
-    value    = sigsci_corp_list.blocked-countries-corp-list.id
+    operator = "in_list"
+    value    = "corp.${fastly_ngwaf_account_list.blocked-countries-corp-list.name}"
   }
 
   # Easily go into blocking by uncommenting the following action
-  # actions {
+  # action {
   #   type = "block"
   # }
 
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.blocked-countries-corp-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.blocked-countries-corp-signal.name}"
   }
 
   depends_on = [
-    sigsci_corp_list.blocked-countries-corp-list,
-    sigsci_corp_signal_tag.blocked-countries-corp-signal,
+    fastly_ngwaf_account_list.blocked-countries-corp-list,
+    fastly_ngwaf_account_signal.blocked-countries-corp-signal,
   ]
 }
 #### Block Requests from Countries that are not revenue generating - End
@@ -147,102 +148,53 @@ resource "sigsci_corp_rule" "blocked-countries-corp-rule" {
 
 
 #### Lower Attack Thresholds - Start
-resource "sigsci_corp_signal_tag" "system-attack-signal" {
-  short_name  = "system-attack"
+resource "fastly_ngwaf_account_signal" "system-attack-signal" {
+  name        = "system-attack"
   description = "Tagging requests with that match any attack"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_rule" "system-attack-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  group_operator   = "all"
-  enabled          = true
-  reason           = "Add a signal for any attack"
-  expiration       = ""
+resource "fastly_ngwaf_account_rule" "system-attack-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "Add a signal for any attack"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
 
-  conditions {
-    type           = "multival"
+  multival_condition {
     field          = "signal"
     group_operator = "all"
     operator       = "exists"
 
-    conditions {
-      type     = "single"
-      field    = "signalType"
-      operator = "inList"
-      value    = sigsci_corp_list.system-attack-signals-list.id
+    condition {
+      field    = "signal_id"
+      operator = "in_list"
+      value    = "corp.${fastly_ngwaf_account_list.system-attack-signals-list.name}"
     }
   }
   #### Easily go into blocking by uncommenting the following action
-  # actions {
+  # action {
   #   type = "block"
   # }
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.system-attack-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.system-attack-signal.name}"
   }
   depends_on = [
-    sigsci_corp_list.system-attack-signals-list,
-    sigsci_corp_signal_tag.system-attack-signal,
+    fastly_ngwaf_account_list.system-attack-signals-list,
+    fastly_ngwaf_account_signal.system-attack-signal,
   ]
 }
 
-# Lower the thresholds for any system attack - Start
-# Docs. https://registry.terraform.io/providers/signalsciences/sigsci/latest/docs/resources/site_alert
-resource "sigsci_site_alert" "any-attack-site-alert-1min" {
-  site_short_name    = var.NGWAF_SITE
-  tag_name           = sigsci_corp_signal_tag.system-attack-signal.id
-  long_name          = "Any system attack alert 1 min"
-  interval           = 1
-  threshold          = 50
-  enabled            = true
-  action             = "info"
-  skip_notifications = true
-
-  depends_on = [
-    sigsci_corp_signal_tag.system-attack-signal,
-  ]
-}
-
-resource "sigsci_site_alert" "any-attack-site-alert-10min" {
-  site_short_name    = var.NGWAF_SITE
-  tag_name           = sigsci_corp_signal_tag.system-attack-signal.id
-  long_name          = "Any system attack alert 10 min"
-  interval           = 10
-  threshold          = 350
-  enabled            = true
-  action             = "info"
-  skip_notifications = true
-
-  depends_on = [
-    sigsci_corp_signal_tag.system-attack-signal
-  ]
-}
-
-resource "sigsci_site_alert" "any-attack-site-alert-60min" {
-  site_short_name    = var.NGWAF_SITE
-  tag_name           = sigsci_corp_signal_tag.system-attack-signal.id
-  long_name          = "Any system attack alert 60 min"
-  interval           = 60
-  threshold          = 1800
-  enabled            = true
-  action             = "info"
-  skip_notifications = true
-
-  depends_on = [
-    sigsci_corp_signal_tag.system-attack-signal
-  ]
-}
-#### Lower Attack Thresholds - End
-
-#### Anomoly Signals - Start
-resource "sigsci_corp_signal_tag" "anomaly-attack-signal" {
-  short_name  = "anomaly-attack"
+#### Anomaly Signals - Start
+resource "fastly_ngwaf_account_signal" "anomaly-attack-signal" {
+  name        = "anomaly-attack"
   description = "Identification of attacks from Anomaly traffic"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_list" "anomaly-attack-signals-list" {
+resource "fastly_ngwaf_account_list" "anomaly-attack-signals-list" {
   name = "anomaly-attack-signals"
   type = "signal"
   entries = [
@@ -257,94 +209,87 @@ resource "sigsci_corp_list" "anomaly-attack-signals-list" {
   ]
 }
 
-resource "sigsci_corp_rule" "anomaly-attack-corp-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  group_operator   = "all"
-  enabled          = true
-  reason           = "Identify attacks from Anomaly Traffic"
-  expiration       = ""
-  conditions {
-    type           = "multival"
+resource "fastly_ngwaf_account_rule" "anomaly-attack-corp-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "Identify attacks from Anomaly Traffic"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
+
+  multival_condition {
     field          = "signal"
     group_operator = "all"
     operator       = "exists"
 
-    conditions {
-      type     = "single"
-      field    = "signalType"
-      operator = "inList"
-      value    = sigsci_corp_list.anomaly-attack-signals-list.id
+    condition {
+      field    = "signal_id"
+      operator = "in_list"
+      value    = "corp.${fastly_ngwaf_account_list.anomaly-attack-signals-list.name}"
     }
   }
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.anomaly-attack-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.anomaly-attack-signal.name}"
   }
   #### Easily go into blocking by uncommenting the following action
-  # actions {
+  # action {
   #   type = "block"
   # }
   depends_on = [
-    sigsci_corp_list.anomaly-attack-signals-list,
-    sigsci_corp_signal_tag.anomaly-attack-signal,
+    fastly_ngwaf_account_list.anomaly-attack-signals-list,
+    fastly_ngwaf_account_signal.anomaly-attack-signal,
   ]
 }
-#### Anomoly Signals - End
+#### Anomaly Signals - End
 
 #### Rate Limiting Enumeration Attempts - Start
-resource "sigsci_site_signal_tag" "bad-response-signal" {
-  site_short_name = var.NGWAF_SITE
-  name            = "bad-response"
-  description     = "Identification of attacks from malicious IPs"
-
+resource "fastly_ngwaf_workspace_signal" "bad-response-signal" {
+  workspace_id = fastly_ngwaf_workspace.tenant_workspace.id
+  name         = "bad-response"
+  description  = "Identification of attacks from malicious IPs"
 }
 
-resource "sigsci_site_rule" "enumeration-attack-rule" {
-  site_short_name = var.NGWAF_SITE
-  type            = "rateLimit"
-  group_operator  = "any"
-  enabled         = true
-  reason          = "Blocking IPs that have too many bad responses. Likely an enumeration attack."
-  expiration      = ""
+resource "fastly_ngwaf_workspace_rule" "enumeration-attack-rule" {
+  workspace_id   = fastly_ngwaf_workspace.tenant_workspace.id
+  type           = "rate_limit"
+  group_operator = "any"
+  enabled        = true
+  description    = "Blocking IPs that have too many bad responses. Likely an enumeration attack."
 
-  conditions {
-    type     = "single"
-    field    = "responseCode"
+  condition {
+    field    = "response_code"
     operator = "like"
     value    = "4[0-9][0-9]"
   }
-  conditions {
-    type     = "single"
-    field    = "responseCode"
+  condition {
+    field    = "response_code"
     operator = "like"
     value    = "5[0-9][0-9]"
   }
-  # actions {
-  #   type          = "blockSignal"
+  # action {
+  #   type          = "block_signal"
   #   signal        = "ALL-REQUESTS"
   #   response_code = 406
   # }
 
-  actions {
-    type   = "logRequest"
-    signal = sigsci_site_signal_tag.bad-response-signal.id
+  action {
+    type   = "log_request"
+    signal = "site.${fastly_ngwaf_workspace_signal.bad-response-signal.name}"
   }
 
   rate_limit {
     threshold = 10
-    interval  = 1
+    interval  = 60
     duration  = 600
+    signal    = "site.${fastly_ngwaf_workspace_signal.bad-response-signal.name}"
     client_identifiers {
-      type = "ip" # Defaults to IP
+      type = "ip"
     }
   }
 
-  signal = sigsci_site_signal_tag.bad-response-signal.id
-
   depends_on = [
-    sigsci_site_signal_tag.bad-response-signal,
+    fastly_ngwaf_workspace_signal.bad-response-signal,
   ]
 }
 
@@ -354,8 +299,8 @@ resource "sigsci_site_rule" "enumeration-attack-rule" {
 output "live_waf_love_output" {
   value = <<tfmultiline
 
-  #### Click the URL to go to the Fastly NGWAF service ####
-  https://dashboard.signalsciences.net/corps/${var.NGWAF_CORP}/sites/${var.NGWAF_SITE}
+  #### Click the URL to go to the Fastly NGWAF workspace ####
+  https://manage.fastly.com/security/ngwaf/workspaces/${fastly_ngwaf_workspace.tenant_workspace.id}/dashboards
 
   tfmultiline
 

--- a/gold-standard-starter/providers.tf
+++ b/gold-standard-starter/providers.tf
@@ -1,9 +1,9 @@
 terraform {
   required_providers {
-    # https://registry.terraform.io/providers/signalsciences/sigsci/latest
-    sigsci = {
-      source  = "signalsciences/sigsci"
-      version = ">= 3.3.0"
+    # https://registry.terraform.io/providers/fastly/fastly/latest/docs
+    fastly = {
+      source  = "fastly/fastly"
+      version = ">= 9.3.0"
     }
   }
 }

--- a/gold-standard-starter/rules_with_edge_deployment.tf
+++ b/gold-standard-starter/rules_with_edge_deployment.tf
@@ -1,151 +1,142 @@
 #### Add rules from https://www.fastly.com/blog/stronger-security-with-a-unified-cdn-and-waf
 
 # Using JA3 signatures and ASNs
-resource "sigsci_corp_list" "malicious-ja3s-list" {
+resource "fastly_ngwaf_account_list" "malicious-ja3s-list" {
   name = "malicious-ja3s-list"
   type = "string"
   entries = [
     "entries_go_here",
   ]
 }
-resource "sigsci_corp_signal_tag" "malicious-ja3-signal" {
-  short_name  = "malicious-ja3"
+resource "fastly_ngwaf_account_signal" "malicious-ja3-signal" {
+  name        = "malicious-ja3"
   description = "corp level malicious ja3"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_rule" "malicious-ja3-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  group_operator   = "all"
-  enabled          = true
-  reason           = "malicious-ja3-rule"
-  expiration       = ""
-  conditions {
-    type           = "multival"
-    field          = "requestHeader"
+resource "fastly_ngwaf_account_rule" "malicious-ja3-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "malicious-ja3-rule"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
+
+  multival_condition {
+    field          = "request_header"
     group_operator = "all"
     operator       = "exists"
-    conditions {
-      type     = "single"
+    condition {
       field    = "name"
       operator = "equals"
       value    = "client-ja3"
     }
 
-    conditions {
-      type     = "single"
-      field    = "valueString"
-      operator = "inList"
-      value    = sigsci_corp_list.malicious-ja3s-list.id
+    condition {
+      field    = "value_string"
+      operator = "in_list"
+      value    = "corp.${fastly_ngwaf_account_list.malicious-ja3s-list.name}"
     }
   }
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.malicious-ja3-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.malicious-ja3-signal.name}"
   }
 }
 
 # Utilizing the ASN header
-resource "sigsci_corp_list" "bad-reputation-asn-list" {
+resource "fastly_ngwaf_account_list" "bad-reputation-asn-list" {
   name = "bad-reputation-asn-list"
   type = "string"
   entries = [
     "entries_go_here",
   ]
 }
-resource "sigsci_corp_signal_tag" "bad-reputation-asn-signal" {
-  short_name  = "bad-reputation-asn"
+resource "fastly_ngwaf_account_signal" "bad-reputation-asn-signal" {
+  name        = "bad-reputation-asn"
   description = "corp level bad reputation asn"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_rule" "bad-reputation-asn-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  group_operator   = "all"
-  enabled          = true
-  reason           = "bad-reputation-asn"
-  expiration       = ""
-  conditions {
-    type           = "multival"
-    field          = "requestHeader"
+resource "fastly_ngwaf_account_rule" "bad-reputation-asn-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "bad-reputation-asn"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
+
+  multival_condition {
+    field          = "request_header"
     group_operator = "all"
     operator       = "exists"
-    conditions {
-      type     = "single"
+    condition {
       field    = "name"
       operator = "equals"
       value    = "asn"
     }
-    conditions {
-      type     = "single"
-      field    = "valueString"
-      operator = "inList"
-      value    = sigsci_corp_list.bad-reputation-asn-list.id
+    condition {
+      field    = "value_string"
+      operator = "in_list"
+      value    = "corp.${fastly_ngwaf_account_list.bad-reputation-asn-list.name}"
     }
   }
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.bad-reputation-asn-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.bad-reputation-asn-signal.name}"
   }
 }
 
 # Taking Advantage of the Proxy Headers
-resource "sigsci_corp_signal_tag" "suspicious-hosting-signal" {
-  short_name  = "suspicious-hosting"
+resource "fastly_ngwaf_account_signal" "suspicious-hosting-signal" {
+  name        = "suspicious-hosting"
   description = "suspicious hosting provider"
+  applies_to  = ["*"]
 }
 
-resource "sigsci_corp_rule" "suspicious-hosting-rule" {
-  site_short_names = []
-  type             = "request"
-  corp_scope       = "global"
-  group_operator   = "all"
-  enabled          = true
-  reason           = "suspicious-hosting"
-  expiration       = ""
-  conditions {
-    type           = "multival"
-    field          = "requestHeader"
+resource "fastly_ngwaf_account_rule" "suspicious-hosting-rule" {
+  applies_to      = ["*"]
+  type            = "request"
+  description     = "suspicious-hosting"
+  enabled         = true
+  group_operator  = "all"
+  request_logging = "sampled"
+
+  multival_condition {
+    field          = "request_header"
     group_operator = "all"
     operator       = "exists"
-    conditions {
-      type     = "single"
+    condition {
       field    = "name"
       operator = "equals"
       value    = "proxy-type"
     }
-    conditions {
-      type     = "single"
-      field    = "valueString"
+    condition {
+      field    = "value_string"
       operator = "equals"
       value    = "hosting"
     }
   }
-  conditions {
-    type           = "multival"
-    field          = "requestHeader"
+  multival_condition {
+    field          = "request_header"
     group_operator = "all"
     operator       = "exists"
-    conditions {
-      type     = "single"
+    condition {
       field    = "name"
       operator = "equals"
       value    = "proxy-desc"
     }
-    conditions {
-      type     = "single"
-      field    = "valueString"
-      operator = "doesNotEqual"
+    condition {
+      field    = "value_string"
+      operator = "does_not_equal"
       value    = "cloud"
     }
   }
-  actions {
-    type   = "addSignal"
-    signal = sigsci_corp_signal_tag.suspicious-hosting-signal.id
+  action {
+    type   = "add_signal"
+    signal = "corp.${fastly_ngwaf_account_signal.suspicious-hosting-signal.name}"
   }
 }
 
-# Optimize NGWAF enforcement with the Edge Cloud Network 
+# Optimize NGWAF enforcement with the Edge Cloud Network
 # Rate limiting rule

--- a/gold-standard-starter/variables.tf
+++ b/gold-standard-starter/variables.tf
@@ -1,20 +1,5 @@
-#### variables for the initial provider setup
-variable "NGWAF_CORP" {
-    type        = string
-    description = "NGWAF Corp where configuration changes will be made."
+#### variables for the Fastly provider setup
+variable "NGWAF_WORKSPACE" {
+  type        = string
+  description = "NGWAF workspace name where configuration changes will be made."
 }
-variable "NGWAF_SITE" {
-    type        = string
-    description = "NGWAF Site where configuration changes will be made."
-}
-variable "NGWAF_EMAIL" {
-    type        = string
-    description = "Email address associated with the token for the NGWAF API."
-}
-variable "NGWAF_TOKEN" {
-    type        = string
-    description = "Secret token for the NGWAF API."
-    sensitive   = true
-}
-
-


### PR DESCRIPTION
### Summary
Migrates the `gold-standard-starter` example from the legacy `signalsciences/sigsci`
provider to the official `fastly/fastly` Terraform provider (`>= 9.3.0`), aligning it
with Fastly's unified account model. Corp-scoped resources become account-scoped,
the NGWAF "site" becomes a "workspace," and authentication consolidates onto a single
Fastly API token.

### Motivation
The `sigsci` provider predates the unified Fastly account model and is being superseded
by first-class NGWAF resources in the `fastly/fastly` provider. Moving the starter onto
the supported provider keeps the demo current, lets it share one credential and one
control plane with the rest of Fastly, and removes the separate Signal Sciences corp/site/email
auth surface.

### Changes

**Provider & auth**
- `providers.tf`: swap `signalsciences/sigsci` (`>= 3.3.0`) → `fastly/fastly` (`>= 9.3.0`).
- `main.tf`: provider block no longer takes `corp` / `email` / `auth_token`; the `fastly`
  provider authenticates via the `FASTLY_API_KEY` environment variable, reused across all
  Fastly resources.
- `variables.tf`: drop `NGWAF_CORP`, `NGWAF_SITE`, `NGWAF_EMAIL`, and the sensitive
  `NGWAF_TOKEN`; add a single `NGWAF_WORKSPACE` variable.

**Resource mapping (corp → account, site → workspace)**
- `sigsci_corp_list` → `fastly_ngwaf_account_list`
- `sigsci_corp_signal_tag` → `fastly_ngwaf_account_signal` (now `name` instead of
  `short_name`, plus required `applies_to = ["*"]`)
- `sigsci_corp_rule` → `fastly_ngwaf_account_rule`
- `sigsci_site_signal_tag` → `fastly_ngwaf_workspace_signal` (now takes `workspace_id`)
- `sigsci_site_rule` → `fastly_ngwaf_workspace_rule`
- New `fastly_ngwaf_workspace` resource (`mode = "log"`) defines the tenant workspace.

**Rule schema rewrites**
- Rule attributes updated: `site_short_names` / `corp_scope` / `reason` / `expiration`
  removed; `description`, `applies_to`, and `request_logging = "sampled"` added.
- Nested `conditions { type = "multival" }` / `conditions { type = "single" }` blocks
  replaced with `multival_condition` / `condition` blocks; `actions` → `action`.
- Field/operator values moved to snake_case: `signalType`→`signal_id`, `inList`→`in_list`,
  `addSignal`→`add_signal`, `responseCode`→`response_code`, `requestHeader`→`request_header`,
  `valueString`→`value_string`, `doesNotEqual`→`does_not_equal`, `rateLimit`→`rate_limit`,
  `logRequest`→`log_request`.
- List/signal references change from `.id` lookups to namespaced string refs
  (`"corp.${...name}"` for account scope, `"site.${...name}"` for workspace scope).

**Threshold model**
- The three separate `sigsci_site_alert` resources (1m/10m/60m) are replaced by the
  workspace's `attack_signal_thresholds` block (`one_minute = 50`, `ten_minutes = 350`,
  `one_hour = 1800`, `immediate = false`).
- Rate-limit rule: `interval` corrected `1` → `60` (seconds) and `signal` moved inside
  the `rate_limit` block.

**Docs & misc**
- `README.md`: "Corp configurations" → "Account configurations", "Site configurations" →
  "Workspace configurations", "Site Alert" → "Workspace Thresholds". Pre-reqs now point to
  a Fastly API token with service create/manage permissions and note the unified account
  model. Apply example uses `TF_VAR_NGWAF_WORKSPACE`.
- Output URL updated from `dashboard.signalsciences.net/corps/.../sites/...` to
  `manage.fastly.com/security/ngwaf/workspaces/${...id}/dashboards`.
- Fixed "Anomoly" → "Anomaly" typo and a relative README link.

### Breaking changes / migration notes
- **Provider swap is breaking.** Run `terraform init -upgrade` before applying.
- **Auth changes:** export `FASTLY_API_KEY` instead of supplying `NGWAF_CORP`/`SITE`/
  `EMAIL`/`TOKEN`; provide the workspace name via `TF_VAR_NGWAF_WORKSPACE`.
- **State:** this PR rewrites the `.tf` resources only — it does not include `import`
  blocks or `moved`/state-migration steps. Applying against state created by the `sigsci`
  provider will require migrating or recreating resources; a fresh `terraform apply` against
  an empty state is the clean path.

### Testing
- [ ] `terraform init -upgrade` resolves `fastly/fastly >= 9.3.0`
- [ ] `terraform validate` passes
- [ ] `terraform apply -parallelism=1` against a test workspace creates expected
      lists, signals, account/workspace rules, and thresholds
- [ ] Output URL links to the correct workspace dashboard